### PR TITLE
fix: standardize copyright holder name in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 petry projects
+Copyright (c) 2026 Don Petry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Standardize the copyright holder name in LICENSE from "petry projects" to "Don Petry"

## Test plan
- [x] Verify the LICENSE file contains the correct copyright holder name

🤖 Generated with [Claude Code](https://claude.com/claude-code)