### PR TITLE
Import org-wide AGENTS.md, remove duplicated standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file follows the AGENTS.md conventions (see https://agents.md/) and provide
 
 > **Organization standards:** This repo inherits shared standards from [petry-projects/.github/AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md). The sections below are project-specific.
 
-> **GitHub Copilot users:** `.github/copilot-instructions.md` points here as the single source of truth.
+> **GitHub Copilot users:** `.github/copilot-instructions.md` points here as the entry point for this repository's instructions; organization-wide guidance lives in the shared AGENTS.md linked above.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 @https://github.com/petry-projects/.github/blob/main/AGENTS.md
 
+> **Org-wide standards:** This project inherits shared development standards from [petry-projects/.github/AGENTS.md](https://github.com/petry-projects/.github/blob/main/AGENTS.md).
+
 # Google Apps Script — Claude Code Project Context
 
 This file provides Claude Code-specific instructions. For comprehensive agent guidelines (repo layout, setup, testing, code style, PR reviews), see [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## Summary
- Imports shared development standards from petry-projects/.github/AGENTS.md
- Removes duplicated sections (TDD, CI, PR reviews, security, agent guidance)
- Keeps project-specific content (repo layout, GAS testing pattern, commands, conventions)

## Depends on
- petry-projects/.github#1

## Test plan
- [ ] Verify no project-specific content was removed
- [ ] Verify all duplicated generic content was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Unified development guidelines by referencing centralized organization standards.
  * Removed redundant guidance sections to reduce duplication across documentation files.
  * Streamlined testing and code style guidance for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->