### PR TITLE
ci: skip Claude Code reviewer on Dependabot PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,7 @@ jobs:
     if: >-
       (github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
-        github.actor != 'dependabot[bot]') ||
+        github.event.pull_request.user.login != 'dependabot[bot]') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
         contains(github.event.comment.body, '@claude') &&
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||


### PR DESCRIPTION
## Summary
- Adds `github.actor != 'dependabot[bot]'` condition to the Claude Code workflow's pull_request trigger
- Prevents the `claude` check from running (and failing) on Dependabot PRs where `CLAUDE_CODE_OAUTH_TOKEN` is unavailable
- Unblocks the dependabot auto-merge workflow when `claude` is a required status check

## Test plan
- [ ] Verify the `claude` check does not run on Dependabot PRs after merge
- [ ] Verify Claude Code still runs on non-Dependabot PRs and on `@claude` mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow automation configuration to refine job execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->