### PR TITLE
ci: add codeql.yml for compliance

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: 'CodeQL'
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '25 14 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (CodeQL)
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          category: 'security'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` to satisfy the compliance requirement for a required `codeql.yml` workflow
- The new file has identical content to the existing `codeql-analysis.yml`
- Closes #103

## Notes

The existing `codeql-analysis.yml` is retained. If desired, it can be removed in a follow-up to avoid running CodeQL twice on each trigger event. However, adding `codeql.yml` is the minimal change required to resolve the compliance finding.

Generated with [Claude Code](https://claude.ai/code)