### PR TITLE
fix(workflows): prettier formatting on feature-ideation cron comment

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -37,7 +37,7 @@ name: Feature Research & Ideation (BMAD Analyst)
 
 on:
   schedule:
-    - cron: '0 7 * * 5'   # Friday 07:00 UTC (3 AM EDT / 2 AM EST)
+    - cron: '0 7 * * 5' # Friday 07:00 UTC (3 AM EDT / 2 AM EST)
   workflow_dispatch:
     inputs:
       focus_area:


### PR DESCRIPTION
Closes #150.

The canonical stub from petry-projects/.github/standards/workflows/ uses three spaces before the cron-line comment. Prettier collapses that to a single space, which made `prettier --check` fail in CI on main, breaking the `CI Pipeline / build-and-test` job.

## Diff

```diff
-    - cron: '0 7 * * 5'   # Friday 07:00 UTC (3 AM EDT / 2 AM EST)
+    - cron: '0 7 * * 5' # Friday 07:00 UTC (3 AM EDT / 2 AM EST)
```

## Test plan

- [x] `npm run check` clean locally
- [ ] CI on this branch — `build-and-test` should pass

## Follow-up

The canonical template in petry-projects/.github has the same multi-space alignment and will keep producing this drift for new adopters. Filing a small PR there to bring it in line with prettier defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)