### PR TITLE
ci: add dependency-audit.yml workflow

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,33 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependency-audit.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md#5-dependency-audit-dependency-auditym
+# Reusable:        petry-projects/.github/.github/workflows/dependency-audit-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All ecosystem-detection and audit logic
+#     lives in the reusable workflow above.
+#   • You MAY change: nothing in this file in normal use. Adopt verbatim.
+#   • You MUST NOT change: trigger events, the `uses:` line, or job name
+#     (used as a required status check).
+#   • If you need different behaviour (new ecosystem, tool version bump),
+#     open a PR against the reusable in the central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Dependency vulnerability audit — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/dependency-audit.yml in your repo.
+# Add "dependency-audit / Detect ecosystems" as a required status check
+# in branch protection.
+name: Dependency audit
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependency-audit.yml` — the org-standard thin caller stub that delegates all audit logic to the reusable workflow at `petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1`
- Copied verbatim from the org template at `petry-projects/.github/standards/workflows/dependency-audit.yml` per the Action Pinning Policy

Closes #104

Generated with [Claude Code](https://claude.ai/code)