### PR TITLE
fix: pin claude-code-reusable.yml to SHA for action-pinning compliance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/claude-code-reusable.yml` from `@v1` to commit SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05` (v1) per the org [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy).
- The SHA was resolved by dereferencing the `v1` annotated tag to its underlying commit.

Closes #155

Generated with [Claude Code](https://claude.ai/code)