### PR TITLE
fix: pin dependabot-automerge reusable workflow to SHA

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml` from mutable `@v1` tag to commit SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1`
- Resolves the compliance finding from the weekly audit (action-pinning policy)

## Changes

Updated `.github/workflows/dependabot-automerge.yml`:
```
uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
```

The SHA was resolved from the `v1` annotated tag via:
```bash
gh api repos/petry-projects/.github/git/refs/tags/v1 --jq '.object.sha'
# → tag object SHA (annotated tag)
gh api repos/petry-projects/.github/git/tags/<tag-object-sha> --jq '.object.sha'
# → ae9709f4466dec60a5733c9e7487f69dcd004e05
```

## Test plan

- [ ] Verify CI passes
- [ ] Confirm compliance audit no longer flags this workflow

Closes #156

Generated with [Claude Code](https://claude.ai/code)