### PR TITLE
fix: pin dependabot-rebase reusable workflow to SHA (issue #157)

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -39,5 +39,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml` from the mutable tag `@v1` to the immutable commit SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1`
- Resolves the `action-pinning` compliance finding flagged by the weekly audit

## Detail

The compliance audit (`unpinned-actions-dependabot-rebase.yml`) requires all `uses:` references to be pinned to a full commit SHA per the [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy).

SHA was resolved by dereferencing the annotated `v1` tag:
```
gh api repos/petry-projects/.github/git/refs/tags/v1   → tag object 208ec2d…
gh api repos/petry-projects/.github/git/tags/208ec2d…  → commit ae9709f…
```

**Note:** The upstream template at `petry-projects/.github/standards/workflows/dependabot-rebase.yml` still uses `@v1`. A follow-up PR against the central repo would bring the template itself into compliance and prevent the finding from recurring in new repos.

Closes #157

Generated with [Claude Code](https://claude.ai/code)