### PR TITLE
fix: pin dependency-audit reusable workflow to SHA

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1


### PR DESCRIPTION
## Summary

- Pins the `petry-projects/.github` reusable workflow reference in `dependency-audit.yml` from the mutable `@v1` tag to the resolved commit SHA `ae9709f4466dec60a5733c9e7487f69dcd004e05` (v1)
- Satisfies the [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy) compliance requirement

Closes #158

Generated with [Claude Code](https://claude.ai/code)