### PR TITLE
fix: enable delete_branch_on_merge for compliance

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,11 @@
 # Repository settings managed via probot/settings
 # https://github.com/probot/settings
 
+repository:
+  # Automatically delete head branches after a pull request is merged
+  # Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults
+  delete_branch_on_merge: true
+
 # Labels — standard set
 # Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set
 labels:


### PR DESCRIPTION
## Summary

- Adds `delete_branch_on_merge: true` to `.github/settings.yml` so probot/settings automatically enables the "Automatically delete head branches" repository setting
- Brings the repository into compliance with the [org standard for repository settings](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults)

Closes #164

Generated with [Claude Code](https://claude.ai/code)