### PR TITLE
fix: enable allow_auto_merge in settings.yml for Dependabot workflow

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,13 @@
 # Repository settings managed via probot/settings
 # https://github.com/probot/settings
 
+# Repository-level settings — standard defaults
+# Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults
+repository:
+  allow_auto_merge: true
+  delete_branch_on_merge: true
+  has_wiki: false
+
 # Labels — standard set
 # Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set
 labels:


### PR DESCRIPTION
## Summary

- Adds `allow_auto_merge: true` to `.github/settings.yml` so the repository setting is declaratively managed via probot/settings
- Also adds `delete_branch_on_merge: true` and `has_wiki: false` to match the full [standard defaults](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults)
- The live GitHub API setting was already `true`; this PR makes it authoritative and prevents future drift

## Root cause

The compliance audit found `allow_auto_merge: null` because the setting had not been explicitly enabled. The `dependabot-automerge.yml` workflow was already in place but requires `allow_auto_merge` to be enabled at the repo level to function.

## Changes

- `.github/settings.yml`: Added `repository` block with `allow_auto_merge: true`, `delete_branch_on_merge: true`, and `has_wiki: false`

Closes #163

Generated with [Claude Code](https://claude.ai/code)