### PR TITLE
fix: set npm open-pull-requests-limit to 0 for security-only policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - 'security'
       - 'dependencies'


### PR DESCRIPTION
## Summary

- Sets `open-pull-requests-limit: 0` for the `npm` ecosystem in `.github/dependabot.yml`
- This suppresses routine version-update PRs while still allowing security-alert-triggered PRs (which bypass the limit)
- `github-actions` ecosystem correctly retains `open-pull-requests-limit: 10` per policy

## Standard Reference

[dependabot-policy.md](https://github.com/petry-projects/.github/blob/main/standards/dependabot-policy.md#policy): Application ecosystems (npm) should use `open-pull-requests-limit: 0` for security-only policy.

Closes #173

Generated with [Claude Code](https://claude.ai/code)