### PR TITLE
fix: set npm open-pull-requests-limit to 0 for security-only policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - 'security'
       - 'dependencies'


### PR DESCRIPTION
## Summary

- Sets `open-pull-requests-limit: 0` for the `npm` ecosystem in `.github/dependabot.yml`
- Per [dependabot policy](https://github.com/petry-projects/.github/blob/main/standards/dependabot-policy.md#policy), application ecosystems must suppress routine version-update PRs; Dependabot security updates bypass this limit so security PRs still get created
- The `github-actions` ecosystem correctly retains `open-pull-requests-limit: 10`

## Change

`.github/dependabot.yml` — npm ecosystem `open-pull-requests-limit` changed from `10` → `0`

Closes #173

Generated with [Claude Code](https://claude.ai/code)