### PR TITLE
ci: add gitleaks secret-scan job (compliance #171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,27 @@ jobs:
 
       - name: Verify no remaining issues after auto-fix
         run: npm run check
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout (full history)
+        # Pin to SHA per Action Pinning Policy (ci-standards.md#action-pinning-policy).
+        # Look up current SHA: gh api repos/actions/checkout/git/refs/tags/v4 --jq '.object.sha'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        # Pinned to SHA per Action Pinning Policy (ci-standards.md#action-pinning-policy).
+        # Refresh with: gh api repos/gitleaks/gitleaks-action/git/refs/tags/v2 --jq '.object.sha'
+        # then dereference if it points at an annotated tag.
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        with:
+          args: detect --source . --redact --verbose --exit-code 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a `secret-scan` job to `.github/workflows/ci.yml` per the org push-protection standard ([`standards/push-protection.md#required-ci-job`](https://github.com/petry-projects/.github/blob/main/standards/push-protection.md#required-ci-job))
- Job uses `gitleaks/gitleaks-action@v2.3.9` (SHA-pinned to `ff98106e4c7b2bc287b24eaf42907196329070c7` per the Action Pinning Policy)
- Full git history checkout (`fetch-depth: 0`) so every commit is scanned, not just the PR diff
- `--redact` flag prevents leaked values from appearing in workflow logs
- `--exit-code 1` fails the build on any finding

## Why this PR

The weekly compliance audit flags `secret_scan_ci_job_present` because `ci.yml` lacked a `gitleaks` job. Previous fix in PR #190 was never merged; this is a clean implementation on the new branch.

## Test plan

- [ ] CI `secret-scan` job passes on this PR
- [ ] Weekly compliance audit no longer flags `secret_scan_ci_job_present` after merge

Closes #171

Generated with [Claude Code](https://claude.ai/code)