### PR TITLE
fix: persist delete_branch_on_merge in settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,11 @@
 # Repository settings managed via probot/settings
 # https://github.com/probot/settings
 
+repository:
+  # Automatically delete head branches after a pull request is merged
+  # Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults
+  delete_branch_on_merge: true
+
 # Labels — standard set
 # Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set
 labels:


### PR DESCRIPTION
## Summary

- Adds `delete_branch_on_merge: true` to `.github/settings.yml` under a `repository:` section
- Ensures probot/settings declaratively manages this setting so it cannot be inadvertently reset
- The GitHub API already returns `true` for this setting (likely set manually), but without the config file entry it is unmanaged

## Why

The weekly compliance audit ([#164](https://github.com/petry-projects/google-app-scripts/issues/164)) checks that `delete_branch_on_merge` is `true` per the [org standard](https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults). Persisting the value in `settings.yml` means probot/settings will enforce it on every run, making the compliance state durable.

## Note on PR #184

PR #184 contains the same fix on a different branch. This PR supersedes it; #184 should be closed once this one merges.

Closes #164

Generated with [Claude Code](https://claude.ai/code)