### PR TITLE
fix: pin dependency-audit reusable workflow to SHA

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   dependency-audit:
-    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1


### PR DESCRIPTION
Pins the reusable workflow reference from `@v1` to the resolved commit SHA to satisfy the [Action Pinning Policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy).

## Changes

```yaml
# Before
uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@v1

# After
uses: petry-projects/.github/.github/workflows/dependency-audit-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
```

The SHA `ee22b427cbce9ecadcf2b436acb57c3adf0cb63d` was resolved from the `v1` tag via `gh api repos/petry-projects/.github/git/refs/tags/v1`.

Closes #158

Generated with [Claude Code](https://claude.ai/code)