### PR TITLE
fix: declaratively enforce allow_auto_merge in settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,13 @@
 # Repository settings managed via probot/settings
 # https://github.com/probot/settings
 
+# Repository-level settings — standard defaults
+# Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#repository-settings--standard-defaults
+repository:
+  allow_auto_merge: true
+  delete_branch_on_merge: true
+  has_wiki: false
+
 # Labels — standard set
 # Reference: https://github.com/petry-projects/.github/blob/main/standards/github-settings.md#labels--standard-set
 labels:


### PR DESCRIPTION
## Summary

- Adds `repository` block to `.github/settings.yml` with `allow_auto_merge: true`, `delete_branch_on_merge: true`, and `has_wiki: false`
- Re-applied the setting via GitHub API PATCH for immediate effect
- Closes the recurring compliance drift: probot/settings will now enforce the value declaratively

## Root cause

The compliance audit (`allow_auto_merge` check) has been flagging this repo since the setting was not declared in `.github/settings.yml`. Although the setting was manually patched via API in prior sessions (PR #185 from 2026-04-14, still unmerged), the absence of a declarative `repository` block means the value can drift back to `null` after certain GitHub platform events. This PR makes the fix permanent by having probot/settings own the setting.

## Why not just merge PR #185?

PR #185 contains the same change, but since it has been open since April 14 without being merged, this PR supersedes it. PR #185 can be closed after this is merged.

## Changes

- `.github/settings.yml`: Added `repository` block with `allow_auto_merge: true`, `delete_branch_on_merge: true`, `has_wiki: false`

Closes #163

Generated with [Claude Code](https://claude.ai/code)