### PR TITLE
ci: add gitleaks secret-scan job (compliance #171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,27 @@ jobs:
 
       - name: Verify no remaining issues after auto-fix
         run: npm run check
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout (full history)
+        # Pin to SHA per Action Pinning Policy (ci-standards.md#action-pinning-policy).
+        # Look up current SHA: gh api repos/actions/checkout/git/refs/tags/v4 --jq '.object.sha'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        # Pinned to SHA per Action Pinning Policy (ci-standards.md#action-pinning-policy).
+        # Refresh with: gh api repos/gitleaks/gitleaks-action/git/refs/tags/v2.3.9 --jq '.object.sha'
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        with:
+          args: detect --source . --redact --verbose --exit-code 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary

- Adds the required `secret-scan` job to `.github/workflows/ci.yml` per the org [push-protection standard](https://github.com/petry-projects/.github/blob/main/standards/push-protection.md#layer-3--ci-secret-scanning-secondary-defense)
- Resolves the `secret_scan_ci_job_present` compliance finding from issue #171
- Pins both actions to SHA per the Action Pinning Policy

## What was added

```yaml
secret-scan:
  name: Secret scan (gitleaks)
  runs-on: ubuntu-latest
  permissions:
    contents: read
    security-events: write
  steps:
    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
      with:
        fetch-depth: 0
    - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
```

## Why this PR over #198

PR [#198](https://github.com/petry-projects/google-app-scripts/pull/198) had the correct action reference but CI failed because `GITLEAKS_LICENSE` was not passed in the `env:` block. `gitleaks-action@v2` requires this for organization repos. This PR adds `GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}` — if the org secret is configured, CI will pass.

**If CI still fails** on "Secret scan (gitleaks)": the `GITLEAKS_LICENSE` secret needs to be added at the org or repo level (obtain from [gitleaks.io](https://gitleaks.io)).

## Compliance check satisfied

The weekly audit greps for `uses: gitleaks/gitleaks-action@` in `ci.yml` — this PR satisfies that check.

Closes #171

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated secret scanning to improve repository security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->