### PR TITLE
fix(ci): pin claude-code-reusable workflow to SHA

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,12 +31,14 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 
 jobs:
   claude-code:
-    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Pin `.github/workflows/claude.yml` reusable workflow reference from tag `@v1` to commit SHA `ee22b427cbce9ecadcf2b436acb57c3adf0cb63d` per the org [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)
- Sync file with org template: add missing `check_run: [completed]` trigger

**Change:**
\`\`\`yaml
# Before
uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@v1

# After
uses: petry-projects/.github/.github/workflows/claude-code-reusable.yml@ee22b427cbce9ecadcf2b436acb57c3adf0cb63d # v1
\`\`\`

Closes #155

Generated with [Claude Code](https://claude.ai/code)