### PR TITLE
fix(workflows): sync workflow stubs to org standard templates

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,8 @@ on:
     types: [created]
   issues:
     types: [labeled]
+  check_run:
+    types: [completed]
 
 permissions: {}
 

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -6,12 +6,13 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All rebase/merge serialization logic
 #     lives in the reusable workflow above.
-#   • You MAY change: nothing in this file in normal use. Adopt verbatim.
+#   • You MAY change: the SHA in the `uses:` line when upgrading the reusable
+#     workflow version (bump SHA to latest main of petry-projects/.github).
 #   • You MUST NOT change: trigger event, the concurrency group name,
-#     the `uses:` line, `secrets: inherit`, or the job-level `permissions:`
-#     block — reusable workflows can be granted no more permissions than the
-#     calling job has, so removing the stanza breaks the reusable's gh API
-#     calls.
+#     the explicit secrets block, or the job-level `permissions:` block —
+#     reusable workflows can be granted no more permissions than the calling
+#     job has, so removing the stanza breaks
+#     the reusable's gh API calls.
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -27,6 +28,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # allow manual trigger to flush Dependabot PR queue
 
 concurrency:
   group: dependabot-update-and-merge
@@ -37,7 +39,9 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      contents: read
-      pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@v1
-    secrets: inherit
+      contents: write   # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
+      pull-requests: write  # re-approve PRs after branch update
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@3c6335c6ee3e2f1a37f3e27e065e28d36d9c0dde # v1
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -28,9 +28,15 @@
 #   2. Replace the `project_context` value with a 3-5 sentence description
 #      of your project, its target users, and the competitive landscape Mary
 #      should research. This is the only required customisation.
-#   3. (Optional) Adjust the schedule cron if Friday morning UTC doesn't suit.
-#   4. Ensure GitHub Discussions is enabled with an "Ideas" category.
-#   5. Confirm the org-level secret CLAUDE_CODE_OAUTH_TOKEN is accessible.
+#   3. (Optional) Copy standards/feature-ideation-sources.md from
+#      petry-projects/.github to .github/feature-ideation-sources.md in your
+#      repo and trim/extend it for your project. Mary uses YOUR copy — not the
+#      central template — so each repo controls its own source list.
+#      Pass `sources_file: path/to/your-list.md` to the reusable workflow if
+#      you prefer a different location.
+#   4. (Optional) Adjust the schedule cron if Friday morning UTC doesn't suit.
+#   5. Ensure GitHub Discussions is enabled with an "Ideas" category.
+#   6. Confirm the org-level secret CLAUDE_CODE_OAUTH_TOKEN is accessible.
 #
 # Standard: https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#8-feature-ideation-feature-ideationyml--bmad-method-repos
 name: Feature Research & Ideation (BMAD Analyst)
@@ -53,6 +59,11 @@ on:
           - quick
           - standard
           - deep
+      dry_run:
+        description: 'Skip Discussion mutations and log them to a JSONL artifact instead. Use this on a fork to smoke-test before going live.'
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -64,18 +75,20 @@ jobs:
   ideate:
     # Permissions cascade from the calling job to the reusable workflow.
     # The reusable workflow's two jobs (gather-signals + analyze) need:
-    #   - contents:    read   (checkout, file reads)
-    #   - issues:      read   (signal collection)
-    #   - pull-requests: read (signal collection)
-    #   - discussions: write  (CRITICAL — create/update Discussion threads)
-    #   - id-token:    write  (claude-code-action OIDC for GitHub App token)
+    #   - contents:      read   (checkout, file reads)
+    #   - issues:        read   (signal collection)
+    #   - pull-requests: read   (signal collection)
+    #   - discussions:   write  (CRITICAL — create/update Discussion threads)
+    #   - id-token:      write  (claude-code-action OIDC for GitHub App token)
+    #   - actions:       read   (feed checkpoint — last successful run query)
     permissions:
       contents: read
       issues: read
       pull-requests: read
       discussions: write
       id-token: write
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@v1
+      actions: read
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@ae9709f4466dec60a5733c9e7487f69dcd004e05 # v1
     with:
       # === CUSTOMISE THIS PER REPO — the only required edit ===
       # Replace this paragraph with a 3-5 sentence description of your project,
@@ -85,7 +98,14 @@ jobs:
         TODO: Replace this with a description of the project and its market.
         Example: "ProjectX is a [type of product] for [target user]. Competitors
         include A, B, C. Key emerging trends in this space: X, Y, Z."
+      # === OPTIONAL: repo-local reputable source list ===
+      # Copy standards/feature-ideation-sources.md from petry-projects/.github
+      # to .github/feature-ideation-sources.md and customise it. The reusable
+      # workflow defaults to that path, so you only need to uncomment and change
+      # sources_file below if you store the list somewhere else.
+      # sources_file: 'docs/feature-ideation-sources.md'
       focus_area: ${{ inputs.focus_area || '' }}
       research_depth: ${{ inputs.research_depth || 'standard' }}
+      dry_run: ${{ inputs.dry_run || false }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- **claude.yml**: Add missing `check_run` trigger event (required by the reusable workflow for CI-gated responses)
- **dependabot-rebase.yml**: Add `workflow_dispatch` trigger, elevate job permissions to `write`, switch from `secrets: inherit` to explicit `APP_ID`/`APP_PRIVATE_KEY` secrets, add SHA pin for the reusable workflow reference
- **feature-ideation.yml**: Add `dry_run` input, `actions: read` permission, SHA pin for the reusable workflow reference, `sources_file` comment, and updated setup instructions

All changes bring these files into alignment with the verbatim standard templates from `petry-projects/.github/standards/workflows/`.

> **Note on the compliance finding:** The pattern `petry-projects/.github/.github/workflows/` is correct GitHub reusable-workflow syntax — the first `.github` is the repository name, and `.github/workflows/` is the path within that repository. The compliance checker (`reusable-workflow-path-duplicate-github`) appears to produce a false positive for repos whose name is `.github`. Copying the standard templates verbatim (the canonical source of truth) addresses the real drift in these files.

Closes #226

## Test plan

- [ ] CI passes (Node.js Tests, lint, coverage)
- [ ] Workflow syntax is valid — no YAML parse errors in Actions UI

Generated with [Claude Code](https://claude.ai/code)