### PR TITLE
fix(workflows): remove duplicate .github/ segment in reusable workflow paths

### DIFF
--- a/.github/workflows/agent-shield.yml
+++ b/.github/workflows/agent-shield.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/agent-shield.yml
 # Standard:        petry-projects/.github/standards/agent-standards.md
-# Reusable:        petry-projects/.github/.github/workflows/agent-shield-reusable.yml
+# Reusable:        petry-projects/.github/workflows/agent-shield-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. The AgentShield CLI scan and the
@@ -30,4 +30,4 @@ permissions:
 
 jobs:
   agent-shield:
-    uses: petry-projects/.github/.github/workflows/agent-shield-reusable.yml@v1
+    uses: petry-projects/.github/workflows/agent-shield-reusable.yml@v1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # SOURCE OF TRUTH: petry-projects/.github/standards/workflows/dependabot-automerge.yml
 # Standard:        petry-projects/.github/standards/dependabot-policy.md
-# Reusable:        petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml
+# Reusable:        petry-projects/.github/workflows/dependabot-automerge-reusable.yml
 #
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All eligibility logic and the GitHub
@@ -35,5 +35,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: petry-projects/.github/.github/workflows/dependabot-automerge-reusable.yml@v1
+    uses: petry-projects/.github/workflows/dependabot-automerge-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Fixes compliance finding `reusable-workflow-path-duplicate-github` (severity: error)
- Changes `petry-projects/.github/.github/workflows/` → `petry-projects/.github/workflows/` in both `agent-shield.yml` and `dependabot-automerge.yml`
- The corrected form matches how the org's own `.github` repo references reusable workflows

## Files changed

- `.github/workflows/agent-shield.yml` — updated `uses:` line and `# Reusable:` comment
- `.github/workflows/dependabot-automerge.yml` — updated `uses:` line and `# Reusable:` comment

## Note on standards templates

The `petry-projects/.github/standards/workflows/` templates still carry the old long form. This fix applies the correct short form directly; the templates themselves should be updated in a separate PR against `petry-projects/.github`.

Closes #225

Generated with [Claude Code](https://claude.ai/code)