### PR TITLE
fix: pin auto-rebase workflow to @v1 per org standard

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Replaces SHA-pinned reusable workflow reference (`@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1`) with the canonical `@v1` tag in `.github/workflows/auto-rebase.yml`
- Brings the workflow into compliance with the org CI standard (centralization tier: thin caller stub must reference `@v1`)
- File now matches the canonical stub from `petry-projects/.github/standards/workflows/auto-rebase.yml` exactly

## Test plan

- [ ] Verify `.github/workflows/auto-rebase.yml` uses `@v1` reference
- [ ] Confirm CI passes on this PR
- [ ] Confirm compliance audit no longer flags this file

Closes #231

Generated with [Claude Code](https://claude.ai/code)