### PR TITLE
fix: pin auto-rebase reusable workflow to SHA (compliance #237)

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -38,5 +38,5 @@ jobs:
     permissions:
       contents: write      # update-branch via GITHUB_TOKEN (may touch .github/workflows/)
       pull-requests: write # post comments on PRs
-    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/auto-rebase-reusable.yml@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9 # v1
     secrets: inherit


### PR DESCRIPTION
## Summary

- Pins `petry-projects/.github/.github/workflows/auto-rebase-reusable.yml` from `@v1` (tag) to `@126c1441ee9cf040f2ce3ef0eda85d459b82f8e9` (commit SHA)
- Adds `# v1` inline comment so the human-readable version tag is still visible
- Satisfies the org-wide [action-pinning policy](https://github.com/petry-projects/.github/blob/main/standards/ci-standards.md#action-pinning-policy)

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm the compliance audit no longer flags `auto-rebase.yml` after merge

Closes #237

Generated with [Claude Code](https://claude.ai/code)