### PR TITLE
ci: add gitleaks secret-scan job (fixes #171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,26 @@ jobs:
 
       - name: Verify no remaining issues after auto-fix
         run: npm run check
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout (full history)
+        # Pin to SHA per Action Pinning Policy (ci-standards.md#action-pinning-policy).
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        # Pinned to SHA per Action Pinning Policy (ci-standards.md#action-pinning-policy).
+        # Verified with: gh api repos/gitleaks/gitleaks-action/git/refs/tags/v2.3.9 --jq '.object.sha'
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        with:
+          args: detect --source . --redact --verbose --exit-code 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary

- Adds the required `secret-scan` job to `.github/workflows/ci.yml` per the [org push-protection standard](https://github.com/petry-projects/.github/blob/main/standards/push-protection.md#required-ci-job) (Layer 3 — CI Secret Scanning)
- Job checks out full git history (`fetch-depth: 0`), runs `gitleaks-action@v2.3.9` (SHA-pinned), with `--redact` and `--exit-code 1`
- SHA verified: `ff98106e4c7b2bc287b24eaf42907196329070c7` ← confirmed via `gh api repos/gitleaks/gitleaks-action/git/refs/tags/v2.3.9`

Closes #171

## Self-review checklist

| Check | Result |
|-------|--------|
| SHA pinning (`actions/checkout`) | `de0fac2e4...` — matches existing ci.yml |
| SHA pinning (`gitleaks/gitleaks-action@v2.3.9`) | `ff98106e4...` — verified via `gh api` |
| `fetch-depth: 0` (full history scan) | Present |
| `--redact` (no secrets in logs) | Present (via `args`) |
| `--exit-code 1` (fails build on finding) | Present (via `args`) |
| `GITHUB_TOKEN` env var | Present |
| `GITLEAKS_LICENSE` env var | Present (references `secrets.GITLEAKS_LICENSE`) |
| `security-events: write` permission | Present (for SARIF upload) |
| Compliance regex match (`uses: gitleaks/gitleaks-action@`) | Matches |

## Notes on previous PRs

PRs [#190](https://github.com/petry-projects/google-app-scripts/pull/190), [#198](https://github.com/petry-projects/google-app-scripts/pull/198), and [#215](https://github.com/petry-projects/google-app-scripts/pull/215) are superseded by this PR and can be closed.

Generated with [Claude Code](https://claude.ai/code)