### PR TITLE
chore: update dependabot-rebase-reusable SHA (fix update-branch + mergeable)

### DIFF
--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -40,7 +40,7 @@ permissions: {}
 jobs:
   dependabot-rebase:
     permissions:
-      pull-requests: write # post @dependabot rebase comments and re-approve PRs
+      pull-requests: write # call update-branch API on behind PRs and merge when ready
     uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@b51e2edf830ea085be0277bcf3174c7b3ec8f958 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/dependabot-rebase.yml
+++ b/.github/workflows/dependabot-rebase.yml
@@ -41,7 +41,7 @@ jobs:
   dependabot-rebase:
     permissions:
       pull-requests: write # post @dependabot rebase comments and re-approve PRs
-    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@3ac78a9b0a7b5bcf0b9a62c284129f3abffdebaa # v1
+    uses: petry-projects/.github/.github/workflows/dependabot-rebase-reusable.yml@b51e2edf830ea085be0277bcf3174c7b3ec8f958 # v1
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Updates the `dependabot-rebase-reusable.yml` caller SHA to `b51e2ed`.

**Changes in new reusable workflow version:**
- Fix: switch from `@dependabot rebase` comments (rejected by Dependabot when posted by a GitHub App bot) to `update-branch` API with APP_TOKEN
- Fix: use GitHub's native `mergeable` state instead of checking all check conclusions (avoids blocking on non-required failing checks like gitleaks false positives)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance automation infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->