### PR TITLE
chore: add org-standard PR Review Mention workflow

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -1,0 +1,38 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/pr-review-mention.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All review-dispatch logic lives in the
+#     reusable workflow above.
+#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
+#     workflow version (e.g. bump `@v1` → `@v2` when petry-projects/.github cuts a new release).
+#   • You MUST NOT change: trigger events or the job-level `permissions:` block —
+#     reusable workflows can be granted no more permissions than the calling job,
+#     so removing the stanza breaks the reusable's gh API calls.
+#   • If you need different behaviour, open a PR against the reusable in the
+#     central repo.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# PR Review Mention — thin caller for the org-level reusable.
+# To adopt: copy this file to .github/workflows/pr-review-mention.yml in your repo.
+# Requires: GH_PAT_WORKFLOWS org secret (already present in petry-projects org).
+name: PR Review — Mention Trigger
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request:
+    types: [review_requested]
+
+permissions: {}
+
+jobs:
+  pr-review-mention:
+    permissions:
+      pull-requests: write
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    secrets: inherit


### PR DESCRIPTION
Adds the org-standard \`pr-review-mention.yml\` thin caller stub deployed via \`scripts/deploy-standard-workflows.sh\`.

Enables \`@petry-review-bot\` mentions and \`donpetry-bot\` reviewer assignments to trigger an immediate code review in this repo. No per-repo secret setup needed — uses the \`GH_PAT_WORKFLOWS\` org secret.