### PR TITLE
chore: sync pr-review-mention.yml stub to @v2

### DIFF
--- a/.github/workflows/pr-review-mention.yml
+++ b/.github/workflows/pr-review-mention.yml
@@ -13,6 +13,8 @@
 #     so removing the stanza breaks the reusable's gh API calls.
 #   • If you need different behaviour, open a PR against the reusable in the
 #     central repo.
+#   • When publishing a new version of this reusable, also update this template and
+#     open a fanout PR across all caller repos.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # PR Review Mention — thin caller for the org-level reusable.
@@ -34,5 +36,5 @@ jobs:
   pr-review-mention:
     permissions:
       pull-requests: write
-    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v1
+    uses: petry-projects/.github/.github/workflows/pr-review-mention-reusable.yml@v2
     secrets: inherit


### PR DESCRIPTION
Bumps `.github/workflows/pr-review-mention.yml` from `@v1` to `@v2` of the org-standard reusable caller stub.

**Why this is a PR:** branch protection requires status checks to pass before direct pushes to `main`.

This file is a thin caller stub — all logic lives in the reusable workflow in `.github`.