### PR TITLE
feat: implement issue #164 — Compliance: delete_branch_on_merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,18 +8,3 @@ playwright-report/
 .dev-lead/
 # compliance-ci-trigger
 # ci-trigger-298
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/
-.dev-lead/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ playwright-report/
 .dev-lead/
 .dev-lead/
 .dev-lead/
+.dev-lead/


### PR DESCRIPTION
Clean up duplicate `.dev-lead/` entries in `.gitignore` (16 duplicates reduced to 1).

Note: `delete_branch_on_merge: true` was already present in `.github/settings.yml` prior to this PR (added in #218). Issue #164 compliance is implemented there; this PR only removes the erroneous duplicate `.gitignore` entries introduced during that attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cleaned up repository ignore rules by removing duplicated entries for a more consistent configuration.

---

**Note:** This release contains no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->