### PR TITLE
fix(dev-lead): grant statuses:read (fixes startup_failure)

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -47,4 +47,4 @@ jobs:
       issues: write
       actions: read
       checks: read
-      statuses: read   # required by dev-lead-reusable.yml since #435
+      statuses: read # required by dev-lead-reusable.yml since #435

--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -47,3 +47,4 @@ jobs:
       issues: write
       actions: read
       checks: read
+      statuses: read   # required by dev-lead-reusable.yml since #435


### PR DESCRIPTION
The reusable workflow has requested `statuses: read` at the job level since #435, but this caller never granted it, so dispatch runs fail with `startup_failure`. Adds `statuses: read` to `jobs.dev-lead.permissions`.

**Urgent:** should merge before the 2026-06-07 04:30 UTC re-sweep (stuck PR #362).

Refs petry-projects/.github#402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. Internal workflow permissions were updated to support development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->