### PR TITLE
fix(dev-lead): add concurrency queue to prevent batch API quota exhaustion

### DIFF
--- a/.github/workflows/dev-lead.yml
+++ b/.github/workflows/dev-lead.yml
@@ -37,6 +37,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: dev-lead
+  cancel-in-progress: false
+
 jobs:
   dev-lead:
     uses: petry-projects/.github-private/.github/workflows/dev-lead-reusable.yml@main

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -37,7 +37,7 @@ echo "  Repo: $REPO"
 echo ""
 
 # ── Preflight ─────────────────────────────────────────────────────────────────
-command -v gh >/dev/null || { echo "Error: gh is required"; exit 1; }
+command -v gh >/dev/null || { echo "Error: gh is required" >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { echo "Error: gh not authenticated"; exit 1; }
 
 # ── Apply security_and_analysis settings ──────────────────────────────────────

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -37,9 +37,7 @@ echo "  Repo: $REPO"
 echo ""
 
 # ── Preflight ─────────────────────────────────────────────────────────────────
-for cmd in gh; do
-  command -v "$cmd" >/dev/null || { echo "Error: $cmd is required"; exit 1; }
-done
+command -v gh >/dev/null || { echo "Error: gh is required"; exit 1; }
 gh auth status >/dev/null 2>&1 || { echo "Error: gh not authenticated"; exit 1; }
 
 # ── Apply security_and_analysis settings ──────────────────────────────────────

--- a/scripts/setup-code-quality-ruleset.sh
+++ b/scripts/setup-code-quality-ruleset.sh
@@ -36,7 +36,7 @@ echo "  Repo:    $REPO"
 echo ""
 
 # ── Preflight ─────────────────────────────────────────────────────────────────
-command -v gh >/dev/null || { echo "Error: gh is required"; exit 1; }
+command -v gh >/dev/null || { echo "Error: gh is required" >&2; exit 1; }
 gh auth status >/dev/null 2>&1 || { echo "Error: gh not authenticated"; exit 1; }
 
 # ── Check if ruleset already exists ───────────────────────────────────────────

--- a/scripts/setup-code-quality-ruleset.sh
+++ b/scripts/setup-code-quality-ruleset.sh
@@ -36,9 +36,7 @@ echo "  Repo:    $REPO"
 echo ""
 
 # ── Preflight ─────────────────────────────────────────────────────────────────
-for cmd in gh; do
-  command -v "$cmd" >/dev/null || { echo "Error: $cmd is required"; exit 1; }
-done
+command -v gh >/dev/null || { echo "Error: gh is required"; exit 1; }
 gh auth status >/dev/null 2>&1 || { echo "Error: gh not authenticated"; exit 1; }
 
 # ── Check if ruleset already exists ───────────────────────────────────────────


### PR DESCRIPTION
Closes #315

## Root Cause

All dev-lead failures in the monitored window (45.8%, 11/24 runs) were caused by Fleet Monitor batch-labeling multiple issues simultaneously, triggering concurrent runs that exhausted shared API quotas:

- **2026-06-08T20:12–20:13** (5 failures): 6 concurrent runs hit GitHub secondary rate limit; the error JSON from the rate-limited `gh api` call ended up as the value of a bash integer variable, causing a comparison failure.
- **2026-06-09T05:30–05:35** (6 failures): 6 concurrent runs exhausted both Claude daily quota and Gemini prepayment credits simultaneously; the `openai/o4-mini` fallback was also unavailable.

The `statuses: read` fix (PR #370) was already merged and did not prevent these failures.

## Fix

- **`dev-lead.yml`**: Add `concurrency: { group: dev-lead, cancel-in-progress: false }`. All dev-lead runs queue globally rather than running in parallel. Concurrent batch-label events now run sequentially and succeed rather than racing for API quota and failing.
- **`scripts/apply-repo-settings.sh`** and **`scripts/setup-code-quality-ruleset.sh`**: Fix pre-existing SC2043 shellcheck warnings (single-item `for` loop → direct `command -v` check) so `dev-lead-lint.sh` passes.

## Test Results

- `bash .dev-lead/scripts/dev-lead-lint.sh`: all checks passed
- `npm run check`: 0 errors (22 pre-existing warnings, unchanged)
- `npm test`: 301/301 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow concurrency configuration for improved job queuing.
  * Enhanced error handling in setup scripts to validate required tools availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->