### PR TITLE
chore: add org-standard add-to-project caller stub (#415)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,63 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE OF TRUTH: petry-projects/.github/standards/workflows/add-to-project.yml
+# Standard:        petry-projects/.github/standards/ci-standards.md
+# Reusable:        petry-projects/.github/.github/workflows/add-to-project-reusable.yml
+#
+# AGENTS — READ BEFORE EDITING:
+#   • This file is a THIN CALLER STUB. All noise-gate / reconcile logic lives
+#     in the reusable workflow above.
+#   • You MAY change: nothing in normal use. The `uses:` ref and `agent_ref`
+#     are pinned to the `add-to-project/stable` channel and move with it — do
+#     not change them to `@main` or a SHA (see ci-standards.md → Reusable
+#     workflow versioning).
+#   • You MUST NOT change: trigger events, the concurrency group, or the
+#     job-level `permissions:` block — a reusable can be granted no more
+#     permissions than the calling job has.
+#   • If you need different behaviour, open a PR against the reusable.
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Auto-add this repo's qualifying issues, PRs, and Ideas-category discussions
+# to the org-level Initiatives project
+# (https://github.com/orgs/petry-projects/projects/1).
+#
+# To adopt: copy this file to .github/workflows/add-to-project.yml in your
+# repo. Requires the org secrets INITIATIVES_APP_ID and
+# INITIATIVES_APP_PRIVATE_KEY (the petry-projects-planner GitHub App), and the
+# app installation must include this repo. See petry-projects/.github#387.
+#
+# Tracking: petry-projects/.github#387, #415
+# Discussion: petry-projects/.github#386
+name: Auto-add to Initiatives project
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled, reopened]
+  pull_request_target:
+    types: [opened, labeled, unlabeled, reopened, ready_for_review]
+  discussion:
+    types: [created, category_changed, deleted, transferred]
+
+permissions: {}
+
+concurrency:
+  group: >-
+    add-to-project-${{ github.event_name == 'discussion'
+    && format('disc-{0}', github.event.discussion.number)
+    || format('{0}-{1}', github.event_name,
+       github.event.issue.number || github.event.pull_request.number) }}
+  cancel-in-progress: false
+
+jobs:
+  add-to-project:
+    permissions:
+      contents: read
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable
+    with:
+      project_id: PVT_kwDOD2inqs4BZq3-
+      project_url: https://github.com/orgs/petry-projects/projects/1
+      agent_ref: add-to-project/stable
+    # Pass only the secrets the reusable declares (least privilege; avoids
+    # `secrets: inherit` handing the reusable every org secret).
+    secrets:
+      INITIATIVES_APP_ID: ${{ secrets.INITIATIVES_APP_ID }}
+      INITIATIVES_APP_PRIVATE_KEY: ${{ secrets.INITIATIVES_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Deploys the org-standard `add-to-project.yml` caller stub (verbatim from `petry-projects/.github` → `standards/workflows/add-to-project.yml`), pinned to the `add-to-project/stable` channel. Adds this repo's qualifying issues/PRs/Ideas-discussions to the org Initiatives board (project 1).

Part of the multi-repo rollout (#415, #414); owner-authorized ahead of the 2026-07-07 gate. Org secrets + the `petry-projects-planner` app install are already in place for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)