### PR TITLE
feat: implement issue #329 — Compliance: non-stub-feature-ideation.yml

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -64,6 +64,10 @@ on:
         required: false
         default: false
         type: boolean
+  # Auto-enhance a freshly-created idea: when a new Discussion is opened in the
+  # Ideas category, the analyst researches and refines it in single-idea mode.
+  discussion:
+    types: [created]
 
 permissions: {}
 
@@ -73,6 +77,14 @@ concurrency:
 
 jobs:
   ideate:
+    # On the `discussion` trigger, only run for new ideas in the Ideas category
+    # and skip the bot's own creations (avoids re-enhancing scheduled output;
+    # enhancement posts a comment, which does not re-fire `discussion: created`).
+    # Schedule/dispatch runs are unaffected by this guard.
+    if: >-
+      github.event_name != 'discussion' ||
+      (github.event.discussion.category.slug == 'ideas' &&
+       github.event.discussion.user.type != 'Bot')
     # Permissions cascade from the calling job to the reusable workflow.
     # The reusable workflow's two jobs (gather-signals + analyze) need:
     #   - contents:      read   (checkout, file reads)
@@ -88,8 +100,12 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@419c90fc96666f064bd1fc6880ebc79460eaeb32 # v1
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@897e4dede3518cdd7273b9dc63e607d0d05cbdda # v1
     with:
+      # On the `discussion: created` trigger this carries the new Discussion's
+      # number → the reusable runs single-idea enhancement mode. Empty on
+      # schedule/dispatch → normal scan. Do not edit this line.
+      target_discussion: ${{ github.event.discussion.number }}
       # === CUSTOMISE THIS PER REPO — the only required edit ===
       # Replace this paragraph with a 3-5 sentence description of your project,
       # its target users, and the competitive landscape. The more specific you


### PR DESCRIPTION
Closes #329

Implemented by dev-lead agent. Please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Ideas automation now also runs when a new GitHub Discussion is created.
  * It can automatically focus on a single newly created idea discussion for more targeted responses.

* **Bug Fixes**
  * The automation now ignores non-Ideas discussions and bot-created discussions, reducing unintended runs.
  * Scheduled and manual runs continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->