### PR TITLE
ci(#614): repin feature-ideation onto ring channels

### DIFF
--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -100,7 +100,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@f0e01b57b2b4c0206a26344fda685be51b4e0a69 # v1
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # On the `discussion: created` trigger this carries the new Discussion's
       # number → the reusable runs single-idea enhancement mode. Empty on


### PR DESCRIPTION
Completes the feature-ideation ring rollout (#614): channels ring0/ring1/stable were cut at v1.1.0 and it's registered in canary-rings.json (petry-projects/.github#661). Repin this consumer from its old ref onto the ring-appropriate feature-ideation channel.