### PR TITLE
chore: sync 1 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -46,7 +46,7 @@ on:
     #          (the job below filters to that label).
     types: [closed, labeled]
   schedule:
-    - cron: '41 3 * * *' # off-peak safety net for missed close events
+    - cron: "41 3 * * *" # off-peak safety net for missed close events
   workflow_dispatch:
 
 permissions:
@@ -73,7 +73,7 @@ jobs:
       - name: Guard — PAT present
         # PAT required: a workflow_dispatch fired with GITHUB_TOKEN never starts a run.
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          GH_TOKEN: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
             echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN never starts a run."
@@ -82,7 +82,7 @@ jobs:
 
       - name: Dispatch central initiative-driver
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_WORKFLOWS }}
+          GH_TOKEN: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
         run: |
           gh workflow run initiative-driver.yml \
             -R petry-projects/.github-private \

--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -76,7 +76,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN never starts a run."
+            echo "::error::Either GH_PAT_DON_PETRY or GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN never starts a run."
             exit 1
           fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3926,9 +3926,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `initiative-driver.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.