### PR TITLE
chore: sync 4 org-standard workflow stub(s) from petry-projects/.github

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -7,7 +7,7 @@
 #   • This file is a THIN CALLER STUB. All noise-gate / reconcile logic lives
 #     in the reusable workflow above.
 #   • You MAY change: nothing in normal use. The `uses:` ref and `agent_ref`
-#     are pinned to the `add-to-project/stable` channel and move with it — do
+#     are pinned to the `add-to-project/v1-stable` channel and move with it — do
 #     not change them to `@main` or a SHA (see ci-standards.md → Reusable
 #     workflow versioning).
 #   • You MUST NOT change: trigger events, the concurrency group, or the
@@ -47,7 +47,7 @@ jobs:
   add-to-project:
     permissions:
       contents: read
-    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/stable # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/add-to-project-reusable.yml@add-to-project/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       project_id: PVT_kwDOD2inqs4BZq3-
       project_url: https://github.com/orgs/petry-projects/projects/1

--- a/.github/workflows/feature-ideation.yml
+++ b/.github/workflows/feature-ideation.yml
@@ -182,7 +182,7 @@ jobs:
       discussions: write
       id-token: write
       actions: read
-    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/stable # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/feature-ideation-reusable.yml@feature-ideation/v1-stable # NOSONAR(githubactions:S7637) first-party channel ref
     with:
       # All values below come from `needs.prep.outputs.*` (resolved in the `prep`
       # job) — NOT the `inputs` context — so this reusable `with:` compiles on the

--- a/.github/workflows/initiative-driver.yml
+++ b/.github/workflows/initiative-driver.yml
@@ -76,7 +76,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::Either GH_PAT_DON_PETRY or GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN never starts a run."
+            echo "::error::GH_PAT_WORKFLOWS is required — a workflow_dispatch fired with GITHUB_TOKEN never starts a run."
             exit 1
           fi
 

--- a/.github/workflows/pr-auto-review.yml
+++ b/.github/workflows/pr-auto-review.yml
@@ -6,17 +6,17 @@
 # AGENTS — READ BEFORE EDITING:
 #   • This file is a THIN CALLER STUB. All readiness-gate logic lives in the
 #     reusable workflow above.
-#   • You MAY change: the tag in the `uses:` line when upgrading the reusable
-#     workflow version (e.g. bump `@v2` → `@v3` when petry-projects/.github cuts
-#     a new release), and the workflow name(s) in `workflow_run.workflows` to
-#     match your repository's CI workflow name(s).
-#   • You MUST NOT change: trigger event types or the job-level `permissions:`
-#     block — reusable workflows can be granted no more permissions than the
-#     calling job, so removing the stanza breaks the reusable's gh API calls.
+#   • You MAY change: the workflow name(s) in `workflow_run.workflows` to match
+#     your repository's CI workflow name(s).
+#   • You MUST NOT change: the `@pr-auto-review/v1-stable` channel in the `uses:`
+#     line — this reusable is on the org-wide moving-channel model (rollout and
+#     rollback are a single central tag move; a frozen `@vN`/`@<sha>` pin is
+#     rejected by the compliance audit). Nor the trigger event types or the
+#     job-level `permissions:` block — reusable workflows can be granted no more
+#     permissions than the calling job, so removing the stanza breaks the
+#     reusable's gh API calls.
 #   • If you need different behaviour, open a PR against the reusable in the
-#     central repo.
-#   • When publishing a new version of this reusable, also update this template
-#     and open a fanout PR across all caller repos.
+#     central repo. The change will propagate everywhere on next run.
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # PR Auto-Review — thin caller for the org-level reusable.
@@ -28,8 +28,9 @@ on:
   # workflow_run fires when a named GitHub Actions workflow completes.
   # check_suite does NOT trigger for GitHub Actions runs, so this is required
   # to catch CI turning green on a PR.
+  # TODO: replace "CI" with your repository's CI workflow name(s).
   workflow_run:
-    workflows: ['Node.js Tests', 'CI Pipeline']
+    workflows: ["CI"]
     types: [completed]
   # check_suite covers third-party CI checks (e.g. SonarCloud, external apps).
   check_suite:
@@ -45,17 +46,13 @@ permissions: {}
 
 jobs:
   pr-auto-review:
-    # Skip fork PRs on pull_request and pull_request_review events — forks don't
-    # receive org secrets, so GH_PAT_WORKFLOWS would be empty and the reusable's
-    # gh api calls would fail. Other triggers (workflow_run, check_suite) always
-    # run in the base-repo context and have full secret access.
-    if: >
-      (github.event_name != 'pull_request' && github.event_name != 'pull_request_review') ||
-      github.event.pull_request.head.repo.fork == false
     permissions:
       pull-requests: read
       checks: read
       actions: read
-    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/stable # NOSONAR(githubactions:S7637) first-party channel ref
+    uses: petry-projects/.github/.github/workflows/pr-auto-review-reusable.yml@pr-auto-review/v1-stable  # NOSONAR(githubactions:S7637) first-party channel ref
     secrets:
-      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_WORKFLOWS }}
+      # Canonical-first fallback (.github-private#1326). The reusable resolves this
+      # secret BY NAME, so only the VALUE changes — the passed key stays named
+      # GH_PAT_WORKFLOWS.
+      GH_PAT_WORKFLOWS: ${{ secrets.GH_PAT_DON_PETRY || secrets.GH_PAT_WORKFLOWS }}


### PR DESCRIPTION
## **User description**
Syncs the following org-standard workflow stub(s) from `petry-projects/.github` (`standards/workflows/`), deployed verbatim:

- `add-to-project.yml`
- `initiative-driver.yml`
- `pr-auto-review.yml`
- `feature-ideation.yml`

Opened by `scripts/deploy-standard-workflows.sh`. Stubs are thin callers; all behaviour lives in the reusables. See `standards/ci-standards.md`. Labeled `standards-sync` and left for the normal review/auto-merge pipeline — the deploy script never merges directly.


___

## **CodeAnt-AI Description**
**Sync org workflow stubs to the new stable release channels**

### What Changed
- Updated the project, initiative, PR review, and feature ideation workflow stubs to use the new `v1-stable` release channels
- PR auto-review now uses the repo’s main CI workflow name and is set up to keep working when the canonical token is available first
- Initiative dispatch now shows a clearer error when the required workflow token is missing

### Impact
`✅ More reliable org workflow updates`
`✅ Fewer PR review setup failures`
`✅ Clearer workflow token errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
