### PR TITLE
feat: implement issue #538 — Compliance: ruleset-drift-pr-quality-dismiss_stale_reviews_on_push

### DIFF
--- a/scripts/tests/setup-pr-quality-ruleset.test.js
+++ b/scripts/tests/setup-pr-quality-ruleset.test.js
@@ -27,6 +27,14 @@ describe('setup-pr-quality-ruleset.sh codified ruleset', () => {
     expect(pullRequestRule?.parameters?.require_last_push_approval).toBe(true)
   })
 
+  it('dismisses stale reviews on push (dismiss_stale_reviews_on_push)', () => {
+    const pullRequestRule = payload.rules.find((r) => r.type === 'pull_request')
+    expect(pullRequestRule).toBeDefined()
+    expect(pullRequestRule?.parameters?.dismiss_stale_reviews_on_push).toBe(
+      true
+    )
+  })
+
   it('has exactly one pull_request rule with all required parameters', () => {
     const pullRequestRules = payload.rules.filter(
       (r) => r.type === 'pull_request'


### PR DESCRIPTION
## **User description**
Closes #538

Implemented by dev-lead agent. Please review.


___

## **CodeAnt-AI Description**
Verify that outdated pull request approvals are dismissed after new commits

### What Changed
- Added coverage confirming the `pr-quality` ruleset dismisses stale reviews when a pull request receives new commits
- Ensures the ruleset retains a single pull request rule with the required approval and stale-review settings

### Impact
`✅ Prevents outdated approvals from satisfying review requirements`
`✅ Keeps pull request compliance checks aligned with the intended ruleset`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that pull-request rules require stale reviews to be dismissed when new changes are pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->